### PR TITLE
Laying down groundwork for better cover icons

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -143,7 +143,7 @@ class LuiPagesGen(object):
         entity = self._ha_api.get_entity(entityId)
         name = name if name is not None else entity.attributes.friendly_name
         if entityType == "cover":
-            icon_id = get_icon_id_ha("cover", state=entity.state, overwrite=icon)
+            icon_id = get_icon_id_ha("cover", state=entity.state, device_class=entity.attributes.get("device_class", ""), overwrite=icon)
             pos = int(entity.attributes.get("current_position", 50))
             if pos == 100:
                 status = "0|1"


### PR DESCRIPTION
Uses device_class to distinguish between different types of cover and passes to get_icon_id_ha. If device_class is not configured, defaults to None (window) as fallback.